### PR TITLE
ci: run module tests on Windows PowerShell 5.1 in shared workflow

### DIFF
--- a/.github/workflows/ModuleCI.yml
+++ b/.github/workflows/ModuleCI.yml
@@ -43,9 +43,29 @@ jobs:
         with:
           name: Unit Test Results (OS ${{ matrix.os }})
           path: ./tests/out/testResults.xml
+  test_powershell:
+    name: Run Tests (Windows PowerShell 5.1)
+    # Windows PowerShell 5.1 (Desktop) is not a runner OS, so it is run as a
+    # separate job using the built-in `powershell` shell on windows-latest.
+    # Modules that declare Windows PowerShell (Desktop) support must build and
+    # test cleanly on the lowest supported engine, not just PowerShell 7+.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        shell: powershell
+        run: ./build.ps1 -Task Test -Bootstrap
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unit Test Results (Windows PowerShell 5.1)
+          path: ./tests/out/testResults.xml
   publish-test-results:
     name: "Publish Unit Tests Results"
-    needs: test
+    needs:
+      - test
+      - test_powershell
     runs-on: ubuntu-latest
     # the test job might be skipped, we don't need to run this job then
     if: success() || failure()

--- a/.github/workflows/ModuleCI.yml
+++ b/.github/workflows/ModuleCI.yml
@@ -67,8 +67,9 @@ jobs:
       - test
       - test_powershell
     runs-on: ubuntu-latest
-    # the test job might be skipped, we don't need to run this job then
-    if: success() || failure()
+    # Publish whenever the test jobs ran (pass or fail); only skip if the
+    # workflow itself was cancelled.
+    if: ${{ !cancelled() }}
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Adds a dedicated `test_powershell` job to the shared `ModuleCI.yml` that builds and runs the full test suite under **Windows PowerShell 5.1 (Desktop)**, alongside the existing PowerShell 7+ matrix (`ubuntu`/`windows`/`macOS`).

Desktop is not a runner OS, so it runs as its own job on `windows-latest` using the built-in `powershell` shell:

```yaml
test_powershell:
  name: Run Tests (Windows PowerShell 5.1)
  runs-on: windows-latest
  steps:
    - uses: actions/checkout@v4
    - name: Test
      shell: powershell
      run: ./build.ps1 -Task Test -Bootstrap
    - name: Upload Unit Test Results
      ...
```

Its results are wired into `publish-test-results` (`needs: [test, test_powershell]`).

## Motivation

Modules that declare Windows PowerShell (Desktop) support need the lowest supported engine exercised by CI, not just PowerShell 7+. PowerShellBuild 0.8.0 shipped a PS7-only ternary that broke module *import* on 5.1, and the pwsh-only test run did not catch it (psake/PowerShellBuild#126).

## Notes / compatibility

- The existing `test` job (id and `Run Pwsh Tests` name) is **unchanged**, so no required-status-check names change for current consumers.
- The new 5.1 job runs unconditionally. No psake repo currently consumes this reusable workflow via `uses:` yet — psake/PowerShellBuild#126 is the first adopter — so blast radius today is limited to that PR.
- If a future consumer does not support Desktop, we can gate this job behind a `workflow_call` input; left unconditional for now per maintainer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)